### PR TITLE
GH actions fix for deprecating set-env and add-path commands

### DIFF
--- a/.github/workflows/poetry-pytest.yml
+++ b/.github/workflows/poetry-pytest.yml
@@ -9,6 +9,8 @@ jobs:
   pytest:
     name: pytest
     runs-on: ubuntu-latest
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
       - uses: actions/checkout@master
       - name: Set up Python 3.7
@@ -18,8 +20,6 @@ jobs:
 
       - name: Install Poetry
         uses: dschep/install-poetry-action@v1.3
-        with:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
       - name: Cache Poetry virtualenv
         uses: actions/cache@v1

--- a/.github/workflows/poetry-pytest.yml
+++ b/.github/workflows/poetry-pytest.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Install Poetry
         uses: dschep/install-poetry-action@v1.3
+        with:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
       - name: Cache Poetry virtualenv
         uses: actions/cache@v1

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -7,6 +7,8 @@ jobs:
   pytest:
     name: pytest
     runs-on: ubuntu-latest
+    env:
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
     steps:
       - uses: actions/checkout@master
       - name: Set up Python 3.7
@@ -16,8 +18,6 @@ jobs:
 
       - name: Install Poetry
         uses: dschep/install-poetry-action@v1.3
-        with:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
       - name: Cache Poetry virtualenv
         uses: actions/cache@v1

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -16,6 +16,8 @@ jobs:
 
       - name: Install Poetry
         uses: dschep/install-poetry-action@v1.3
+        with:
+          ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
       - name: Cache Poetry virtualenv
         uses: actions/cache@v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "redisbench-admin"
-version = "0.1.25"
+version = "0.1.26"
 description = "Redis benchmark run helper. A wrapper around Redis and Redis Modules benchmark tools ( ftsb_redisearch, memtier_benchmark, redis-benchmark, aibench, etc... )."
 authors = ["filipecosta90 <filipecosta.90@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
Further reference: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/